### PR TITLE
Updates RSpec so that tests run correctly on 1.9.3-p194

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "rspec", "~> 2.3.0"
-  gem "bundler", "~> 1.0.0"
-  gem "jeweler", "~> 1.5.2"
+  gem "rspec", "~> 2.11.0"
+  gem "bundler", "~> 1.0"
+  gem "jeweler", "~> 1.8.4"
   gem "rcov", ">= 0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,32 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
+    diff-lcs (1.1.3)
     git (1.2.5)
-    jeweler (1.5.2)
-      bundler (~> 1.0.0)
+    jeweler (1.8.4)
+      bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    rake (0.8.7)
+      rdoc
+    json (1.7.5)
+    rake (0.9.2.2)
     rcov (0.9.9)
-    rspec (2.3.0)
-      rspec-core (~> 2.3.0)
-      rspec-expectations (~> 2.3.0)
-      rspec-mocks (~> 2.3.0)
-    rspec-core (2.3.1)
-    rspec-expectations (2.3.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.3.0)
+    rdoc (3.12)
+      json (~> 1.4)
+    rspec (2.11.0)
+      rspec-core (~> 2.11.0)
+      rspec-expectations (~> 2.11.0)
+      rspec-mocks (~> 2.11.0)
+    rspec-core (2.11.1)
+    rspec-expectations (2.11.3)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.11.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.0.0)
-  jeweler (~> 1.5.2)
+  bundler (~> 1.0)
+  jeweler (~> 1.8.4)
   rcov
-  rspec (~> 2.3.0)
+  rspec (~> 2.11.0)

--- a/values.gemspec
+++ b/values.gemspec
@@ -54,20 +54,20 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rspec>, ["~> 2.3.0"])
-      s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
-      s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
+      s.add_development_dependency(%q<rspec>, ["~> 2.11.0"])
+      s.add_development_dependency(%q<bundler>, ["~> 1.0"])
+      s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<rspec>, ["~> 2.3.0"])
-      s.add_dependency(%q<bundler>, ["~> 1.0.0"])
-      s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
+      s.add_dependency(%q<rspec>, ["~> 2.11.0"])
+      s.add_dependency(%q<bundler>, ["~> 1.0"])
+      s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
       s.add_dependency(%q<rcov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rspec>, ["~> 2.3.0"])
-    s.add_dependency(%q<bundler>, ["~> 1.0.0"])
-    s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
+    s.add_dependency(%q<rspec>, ["~> 2.11.0"])
+    s.add_dependency(%q<bundler>, ["~> 1.0"])
+    s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
     s.add_dependency(%q<rcov>, [">= 0"])
   end
 end


### PR DESCRIPTION
- I also had to upgrade jeweler to make it play nicely with my version
  of bundler. Newer versions of jeweler lock to bundler '~>1.0' instead
  of '~>1.0.0'

More details about the fix in RSpec at https://github.com/rspec/rspec-core/pull/258
