### PR TITLE
Fixing double standard with nil handling.

### DIFF
--- a/lib/values.rb
+++ b/lib/values.rb
@@ -17,13 +17,9 @@ class Value
       def self.with(hash)
         args = []
         self::VALUE_ATTRS.each do |field|
-          val = hash[field]
-          if val
-            args << val
-          else
-            raise ArgumentError.new("Missing field: #{field}")
-          end
+          args << hash.fetch(field)
         end
+
         unexpected_keys = hash.keys - self::VALUE_ATTRS
         if unexpected_keys.any?
           raise ArgumentError.new("Unexpected hash keys: #{unexpected_keys}")

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -71,6 +71,13 @@ describe 'values' do
     end.to raise_error
   end
 
+  it 'does not error when fields are explicitly nil' do
+    Money = Value.new(:amount, :denomination)
+    expect do
+      Money.with(:amount => 1, :denomination => nil)
+    end.not_to raise_error
+  end
+
   describe '#hash and equality' do
     Y = Value.new(:x, :y)
 


### PR DESCRIPTION
Noticed a double standard when it cam to nil handling on the two initialiser methods.

`.new` just checks for the presence of the field, where as `.with` checks for a truthy value for the field.

Not to sure if you want to go this way or make `.new` check the value as well. I just though it was a little weird I could get away with one and not the other.

-- Chris
