### PR TITLE
Remove inconsistency in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ p.x
 # => 3
 ```
 
-Values also supports customization of value classes by passing a block to `Value.new`:
+Values also supports customization of value classes inheriting from `Value.new`:
 
 ```ruby
 class Point < Value.new(:x, :y)


### PR DESCRIPTION
The example shows inheriting from an instance of a class, not passing in a block.
