### PR TITLE
Throw errors when .with is given missing keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ group :development do
   gem "rspec", "~> 2.11.0"
   gem "bundler", "~> 1.0"
   gem "jeweler", "~> 1.8.4"
-  gem "rcov", ">= 0"
+  gem "simplecov", ">= 0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.3)
+    docile (1.1.5)
     git (1.2.5)
     jeweler (1.8.4)
       bundler (~> 1.0)
@@ -9,8 +10,8 @@ GEM
       rake
       rdoc
     json (1.7.5)
+    multi_json (1.10.1)
     rake (0.9.2.2)
-    rcov (0.9.9)
     rdoc (3.12)
       json (~> 1.4)
     rspec (2.11.0)
@@ -21,6 +22,11 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
+    simplecov (0.9.2)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.9.0)
+    simplecov-html (0.9.0)
 
 PLATFORMS
   ruby
@@ -28,5 +34,5 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.0)
   jeweler (~> 1.8.4)
-  rcov
   rspec (~> 2.11.0)
+  simplecov

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -25,7 +25,7 @@ class Value
 
         missing_keys = self::VALUE_ATTRS - hash.keys
         if missing_keys.any?
-          raise ArgumentError.new("Missing hash keys: #{missing_keys}")
+          raise ArgumentError.new("Missing hash keys: #{missing_keys} (got keys #{hash.keys})")
         end
 
         new(*hash.values_at(*self::VALUE_ATTRS))

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -23,6 +23,11 @@ class Value
           raise ArgumentError.new("Unexpected hash keys: #{unexpected_keys}")
         end
 
+        missing_keys = self::VALUE_ATTRS - hash.keys
+        if missing_keys.any?
+          raise ArgumentError.new("Missing hash keys: #{missing_keys}")
+        end
+
         new(*hash.values_at(*self::VALUE_ATTRS))
       end
 

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -78,8 +78,8 @@ describe 'values' do
 
   it 'errors if you instantiate it from a hash with missing fields' do
     expect do
-      Money.with
-    end.to raise_error
+      Money.with({})
+    end.to raise_error(ArgumentError)
   end
 
   it 'does not error when fields are explicitly nil' do


### PR DESCRIPTION
Fixes #18
Couldn't bundle install with rcov on ruby >2, so I updated it to simplecov. 