### PR TITLE
Fix edge case: don’t allow zero fields

### DIFF
--- a/lib/values.rb
+++ b/lib/values.rb
@@ -1,5 +1,7 @@
 class Value
   def self.new(*fields, &block)
+    raise ArgumentError.new('wrong number of arguments (0 for 1+)') if fields.empty?
+
     Class.new do
       attr_reader(:hash, *fields)
 

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -1,5 +1,9 @@
 require File.expand_path(File.dirname(__FILE__) + '/../lib/values')
 describe 'values' do
+  it 'raises argument error if given zero fields' do
+    expect { Value.new }.to raise_error(ArgumentError, 'wrong number of arguments (0 for 1+)')
+  end
+
   Cell = Value.new(:alive)
 
   it 'stores a single field' do


### PR DESCRIPTION
The proposed fix here will raise the same
ArgumentError message that `Struct.new()` raises:
'wrong number of arguments (0 for 1+)'