### PR TITLE
Add #with method supporting hash args

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ p.x
 # => 3
 ```
 
-Values also allows copying some values and replacing others:
+Values can copy and replace fields using a hash:
 
 ```ruby
-p = Point.with(x: 0, y: 0)
-q = p.copy(y: 2)
-# => #<Point x=0, y=2>
+p = Point.with(x: 1, y: -1)
+q = p.with(y: 2)
+# => #<Point x=1, y=2>
 ```
 
 Values also supports customization of value classes inheriting from `Value.new`:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ p.x
 # => 3
 ```
 
+Values also allows copying some values and replacing others:
+
+```ruby
+p = Point.with(x: 0, y: 0)
+q = p.copy(y: 2)
+# => #<Point x=0, y=2>
+```
+
 Values also supports customization of value classes inheriting from `Value.new`:
 
 ```ruby

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -48,20 +48,10 @@ class Value
         "#<#{self.class.name} #{attributes}>"
       end
 
-      def copy(*args)
-        return self if args.empty?
-
-        if args.size > self.class::VALUE_ATTRS.size
-          raise ArgumentError.new("wrong number of arguments, #{args.size} for #{self.class::VALUE_ATTRS.size}")
-        end
-
-        if args.size == 1 && args[0].is_a?(Hash)
-          merged_hash = Hash[self.class::VALUE_ATTRS.map { |field| [field, send(field)]}].merge(args[0])
-          self.class.with(merged_hash)
-        else
-          merged_args = args + values.drop(args.size)
-          self.class.new(*merged_args)
-        end
+      def with(hash = {})
+        return self if hash.empty?
+        merged_hash = Hash[self.class::VALUE_ATTRS.map { |field| [field, send(field)]}].merge(hash)
+        self.class.with(merged_hash)
       end
 
       class_eval &block if block

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -48,6 +48,22 @@ class Value
         "#<#{self.class.name} #{attributes}>"
       end
 
+      def copy(*args)
+        return self if args.empty?
+
+        if args.size > self.class::VALUE_ATTRS.size
+          raise ArgumentError.new("wrong number of arguments, #{args.size} for #{self.class::VALUE_ATTRS.size}")
+        end
+
+        if args.size == 1 && args[0].is_a?(Hash)
+          merged_hash = Hash[self.class::VALUE_ATTRS.map { |field| [field, send(field)]}].merge(args[0])
+          self.class.with(merged_hash)
+        else
+          merged_args = args + values.drop(args.size)
+          self.class.new(*merged_args)
+        end
+      end
+
       class_eval &block if block
     end
   end

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -129,4 +129,50 @@ describe 'values' do
       Point.new(10, 13).values.should == [10, 13]
     end
   end
+
+  describe '#copy' do
+    let(:p) { Point.new(0, 0) }
+
+    describe 'with no arguments' do
+      it 'returns an object equal by value' do
+        expect(p.copy).to eq(p)
+      end
+
+      it 'returns an object equal by identity' do
+        expect(p.copy).to equal(p)
+      end
+    end
+
+    describe 'with positional arguments' do
+      it 'replaces all field value' do
+        expect(p.copy(1, 2)).to eq(Point.new(1, 2))
+      end
+
+      it 'defaults to current values if missing later arguments' do
+        expect(p.copy(1)).to eq(Point.new(1, 0))
+      end
+
+      it 'replaces a field value even if new value is nil' do
+        expect(p.copy(nil)).to eq(Point.new(nil, 0))
+      end
+
+      it 'raises argument error if too many arguments' do
+        expect { p.copy(1, 2, 3) }.to raise_error(ArgumentError, 'wrong number of arguments, 3 for 2')
+      end
+    end
+
+    describe 'with hash arguments' do
+      it 'replaces all field values' do
+        expect(p.copy({ :x => 1, :y => 2 })).to eq(Point.new(1, 2))
+      end
+
+      it 'defaults to current values if missing' do
+        expect(p.copy({ :y => 2 })).to eq(Point.new(0, 2))
+      end
+
+      it 'raises argument error if unknown field' do
+        expect { p.copy({ :foo => 3 }) }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -130,48 +130,30 @@ describe 'values' do
     end
   end
 
-  describe '#copy' do
-    let(:p) { Point.new(0, 0) }
+  describe '#with' do
+    let(:p) { Point.new(1, -1) }
 
     describe 'with no arguments' do
       it 'returns an object equal by value' do
-        expect(p.copy).to eq(p)
+        expect(p.with).to eq(p)
       end
 
       it 'returns an object equal by identity' do
-        expect(p.copy).to equal(p)
-      end
-    end
-
-    describe 'with positional arguments' do
-      it 'replaces all field value' do
-        expect(p.copy(1, 2)).to eq(Point.new(1, 2))
-      end
-
-      it 'defaults to current values if missing later arguments' do
-        expect(p.copy(1)).to eq(Point.new(1, 0))
-      end
-
-      it 'replaces a field value even if new value is nil' do
-        expect(p.copy(nil)).to eq(Point.new(nil, 0))
-      end
-
-      it 'raises argument error if too many arguments' do
-        expect { p.copy(1, 2, 3) }.to raise_error(ArgumentError, 'wrong number of arguments, 3 for 2')
+        expect(p.with).to equal(p)
       end
     end
 
     describe 'with hash arguments' do
       it 'replaces all field values' do
-        expect(p.copy({ :x => 1, :y => 2 })).to eq(Point.new(1, 2))
+        expect(p.with({ :x => 1, :y => 2 })).to eq(Point.new(1, 2))
       end
 
       it 'defaults to current values if missing' do
-        expect(p.copy({ :y => 2 })).to eq(Point.new(0, 2))
+        expect(p.with({ :y => 2 })).to eq(Point.new(1, 2))
       end
 
       it 'raises argument error if unknown field' do
-        expect { p.copy({ :foo => 3 }) }.to raise_error(ArgumentError)
+        expect { p.with({ :foo => 3 }) }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
The `#copy` method allows you to start with an instance
of a `Value` type, and obtain a new instance by replacing
some or all of the field values.

This is very similar to the `#copy` method of Scala case
classes.

Example:

```ruby
Point = Value.new(:x, :y)
p0 = Point.new(0, 0)
p1 = p0.copy(x: 5) # x as hash arg
p2 = p0.copy(y: 5) # y as hash arg
p3 = p0.copy(5, 5) # both as positional args
```