### PR TITLE
Git ignore local RVM conf (.ruby-version, -gemset)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ doc
 .bundle
 Gemfile.lock
 
+# rvm
+.ruby-version
+.ruby-gemset
+
 # jeweler generated
 pkg
 


### PR DESCRIPTION
These files are used by RVM to configure 
  - which ruby version to use by default in this dir
  - a named, isolated gemset to use in this dir

This commit simply excludes these local config files
from git.