### PR TITLE
Add a #to_h method to support conversion to Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ q = p.with(y: 2)
 # => #<Point x=1, y=2>
 ```
 
+Value classes can be converted to a hash, like OpenStruct:
+
+```ruby
+Point.with(x: 1, y: -1).to_h
+# => {:x=>1, :y=>-1}
+```
+
 Values also supports customization of value classes inheriting from `Value.new`:
 
 ```ruby

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -56,6 +56,10 @@ class Value
         self.class.with(merged_hash)
       end
 
+      def to_h
+        Hash[self.class::VALUE_ATTRS.map { |field| [field, send(field)]}]
+      end
+
       class_eval &block if block
     end
   end

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -46,18 +46,17 @@ class Value
       end
 
       def inspect
-        attributes = self.class::VALUE_ATTRS.map { |field| "#{field}=#{send(field).inspect}" }.join(", ")
+        attributes = to_h.map { |field, value| "#{field}=#{value.inspect}" }.join(", ")
         "#<#{self.class.name} #{attributes}>"
       end
 
       def with(hash = {})
         return self if hash.empty?
-        merged_hash = Hash[self.class::VALUE_ATTRS.map { |field| [field, send(field)]}].merge(hash)
-        self.class.with(merged_hash)
+        self.class.with(to_h.merge(hash))
       end
 
       def to_h
-        Hash[self.class::VALUE_ATTRS.map { |field| [field, send(field)]}]
+        Hash[self.class::VALUE_ATTRS.zip(values)]
       end
 
       class_eval &block if block

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -134,6 +134,16 @@ describe 'values' do
     end
   end
 
+  ManyAttrs = Value.new(:f, :e, :d, :c, :b, :a)
+
+  describe '#inspect' do
+    let(:v) { ManyAttrs.new(6, 5, 4, 3, 2, 1) }
+
+    it 'returns a string containing attributes in their expected order' do
+      expect(v.inspect).to eq('#<ManyAttrs f=6, e=5, d=4, c=3, b=2, a=1>')
+    end
+  end
+
   describe '#with' do
     let(:p) { Point.new(1, -1) }
 

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -161,4 +161,12 @@ describe 'values' do
       end
     end
   end
+
+  describe '#to_h' do
+    let(:p) { Point.new(1, -1) }
+
+    it 'returns a hash of fields and values' do
+      expect(p.to_h).to eq({ :x => 1, :y => -1 })
+    end
+  end
 end


### PR DESCRIPTION
Like OpenStruct, allow conversion to a Hash using 
`#to_h`. We already support conversion from a Hash
using `.with`.