### PR TITLE
Make to_h recursive

### DIFF
--- a/lib/values.rb
+++ b/lib/values.rb
@@ -74,7 +74,11 @@ class Value
       end
 
       def to_h
-        Hash[to_a.map{|k, v| [k, Value.try_to_h(v)]}]
+        Hash[to_a]
+      end
+
+      def recursive_to_h
+        Hash[to_a.map{|k, v| [k, Value.coerce_to_h(v)]}]
       end
 
       def to_a
@@ -87,12 +91,12 @@ class Value
 
   protected
 
-  def self.try_to_h(v)
+  def self.coerce_to_h(v)
     case
     when v.is_a?(Hash)
-      Hash[v.map{|hk, hv| [hk, try_to_h(hv)]}]
+      Hash[v.map{|hk, hv| [hk, coerce_to_h(hv)]}]
     when v.respond_to?(:map)
-      v.map{|x| try_to_h(x)}
+      v.map{|x| coerce_to_h(x)}
     when v && v.respond_to?(:to_h)
       v.to_h
     else

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -74,7 +74,7 @@ class Value
       end
 
       def to_h
-        Hash[to_a]
+        Hash[to_a.map{|k, v| [k, Value.try_to_h(v)]}]
       end
 
       def to_a
@@ -82,6 +82,21 @@ class Value
       end
 
       class_eval &block if block
+    end
+  end
+
+  protected
+
+  def self.try_to_h(v)
+    case
+    when v.is_a?(Hash)
+      Hash[v.map{|hk, hv| [hk, try_to_h(hv)]}]
+    when v.respond_to?(:map)
+      v.map{|x| try_to_h(x)}
+    when v && v.respond_to?(:to_h)
+      v.to_h
+    else
+      v
     end
   end
 end

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -193,17 +193,19 @@ describe Value do
     it 'returns a hash of fields and values' do
       expect(Point.new(1, -1).to_h).to eq({ :x => 1, :y => -1 })
     end
+  end
 
+  describe '#recursive_to_h' do
     it 'converts nested values' do
-      expect(Rectangle.new(Point.new(0, 1), Point.new(1, 0)).to_h).to eq({:top_left => {:x => 0, :y => 1}, :bottom_right => {:x => 1, :y => 0}})
+      expect(Rectangle.new(Point.new(0, 1), Point.new(1, 0)).recursive_to_h).to eq({:top_left => {:x => 0, :y => 1}, :bottom_right => {:x => 1, :y => 0}})
     end
 
     it 'converts values in an array field' do
-      expect(Board.new([Cell.new(false), Cell.new(true)]).to_h).to eq({:cells => [{:alive => false}, {:alive => true}]})
+      expect(Board.new([Cell.new(false), Cell.new(true)]).recursive_to_h).to eq({:cells => [{:alive => false}, {:alive => true}]})
     end
 
     it 'converts values in a hash field' do
-      expect(Board.new({:mine => Cell.new(true), :yours => Cell.new(false)}).to_h).to eq({:cells => {:mine => {:alive => true}, :yours => {:alive => false}}})
+      expect(Board.new({:mine => Cell.new(true), :yours => Cell.new(false)}).recursive_to_h).to eq({:cells => {:mine => {:alive => true}, :yours => {:alive => false}}})
     end
   end
 

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -26,6 +26,10 @@ describe Value do
 
   Point = Value.new(:x, :y)
 
+  Rectangle = Value.new(:top_left, :bottom_right)
+
+  Board = Value.new(:cells)
+
   describe '.new and the fields of a value class' do
     it 'stores a single field' do
       expect(Cell.new(true).alive).to eq(true)
@@ -184,6 +188,18 @@ describe Value do
     it 'returns a hash of fields and values' do
       expect(Point.new(1, -1).to_h).to eq({ :x => 1, :y => -1 })
     end
+
+    it 'converts nested values' do
+      expect(Rectangle.new(Point.new(0, 1), Point.new(1, 0)).to_h).to eq({:top_left => {:x => 0, :y => 1}, :bottom_right => {:x => 1, :y => 0}})
+    end
+
+    it 'converts values in an array field' do
+      expect(Board.new([Cell.new(false), Cell.new(true)]).to_h).to eq({:cells => [{:alive => false}, {:alive => true}]})
+    end
+
+    it 'converts values in a hash field' do
+      expect(Board.new({:mine => Cell.new(true), :yours => Cell.new(false)}).to_h).to eq({:cells => {:mine => {:alive => true}, :yours => {:alive => false}}})
+    end
   end
 
   describe '#to_a' do
@@ -191,5 +207,4 @@ describe Value do
       expect(Point.new(1, -1).to_a).to eq([[:x, 1], [:y, -1]])
     end
   end
-
 end

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -158,6 +158,7 @@ describe Value do
 
   describe '#with' do
     let(:p) { Point.new(1, -1) }
+    let(:b) { Point.new(Set.new([1, 2, 3]), Set.new([4, 5, 6])) }
 
     describe 'with no arguments' do
       it 'returns an object equal by value' do
@@ -172,6 +173,10 @@ describe Value do
     describe 'with hash arguments' do
       it 'replaces all field values' do
         expect(p.with({ :x => 1, :y => 2 })).to eq(Point.new(1, 2))
+      end
+
+      it 'handles nested args' do
+        expect( b.with({:x => Set.new([1])})).to eq(Point.new(Set.new([1]), b.y))
       end
 
       it 'defaults to current values if missing' do


### PR DESCRIPTION
*tl;dr* - Here's a first pass at making `to_h` recursive.

```ruby
Cell = Value.new(:alive)
Board = Value.new(:cells)
Board.new([Cell.new(false), Cell.new(true)]).to_h
# => {:cells=>[{:alive=>false}, {:alive=>true}]}
```

#### Sup?

to_h now recurses down through it's member fields and tries to coerce them `to_h`. Collections that respond to `map` have each element coerced (Hashes are an explicit exception, since `hash.map` doesn't return a Hash). Nil's also explicitly excluded because `nil.to_h == {}`.

Leme know if you think it makes sense to be on the lookout for any other special field types.