### PR TITLE
Freeze Class object to be more strict

### DIFF
--- a/lib/values.rb
+++ b/lib/values.rb
@@ -101,6 +101,8 @@ class Value
       end
 
       class_eval &block if block
+
+      freeze
     end
   end
 

--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -230,4 +230,13 @@ describe Value do
       expect(Point.new(1, -1).to_a).to eq([[:x, 1], [:y, -1]])
     end
   end
+
+  describe '.attr_reader' do
+    Freeze = Value.new(:x)
+    it 'raises runtime error if open and change class' do
+      error_class = RUBY_VERSION >= '1.9' ? RuntimeError : TypeError
+      expect { class Freeze; attr_reader(:y); end }.to raise_error(error_class)
+    end
+  end
+
 end


### PR DESCRIPTION
Thank you for awesome library. I like this and often use with my work.

I propose this changes which make more strict for dealing class definition to this library.
Currently, we can change value class definition via open-class mechanism. So, I think that we shouldn't change class definition of value object for immutability even though in ruby world.

Well ... but, this may break compatibility for someone.
How do you like it?