### PR TITLE
Values::ArgumentError - exception class containing missing/unexpected constructor arguments

### DIFF
--- a/spec/values_spec.rb
+++ b/spec/values_spec.rb
@@ -42,7 +42,12 @@ describe Value do
     end
 
     it 'raises argument errors if not given the right number of arguments' do
-      expect { Point.new }.to raise_error(ArgumentError, 'wrong number of arguments, 0 for 2')
+      expect { Point.new }.to raise_error do |error|
+        expect(error).to be_a(Values::ArgumentError)
+        expect(error.message).to eq('wrong number of arguments, 0 for 2')
+        expect(error.missing_keys).to contain_exactly(:x, :y)
+        expect(error.unexpected_keys).to be_nil
+      end
     end
   end
 
@@ -100,11 +105,19 @@ describe Value do
   end
 
   it 'errors if you instantiate it from a hash with unrecognised fields' do
-    expect { Money.with(:unrecognized_field => 1, :amount => 2, :denomination => 'USD') }.to raise_error(ArgumentError)
+    expect { Money.with(:unrecognized_field => 1, :amount => 2, :denomination => 'USD') }.to raise_error do |error|
+      expect(error).to be_a(Values::ArgumentError)
+      expect(error.missing_keys).to be_empty
+      expect(error.unexpected_keys).to contain_exactly(:unrecognized_field)
+    end
   end
 
   it 'errors if you instantiate it from a hash with missing fields' do
-    expect { Money.with({}) }.to raise_error(ArgumentError)
+    expect { Money.with({}) }.to raise_error do |error|
+      expect(error).to be_a(Values::ArgumentError)
+      expect(error.missing_keys).to contain_exactly(:amount, :denomination)
+      expect(error.unexpected_keys).to be_empty
+    end
   end
 
   it 'does not error when fields are explicitly nil' do
@@ -200,7 +213,11 @@ describe Value do
       end
 
       it 'raises argument error if unknown field' do
-        expect { p.with({ :foo => 3 }) }.to raise_error(ArgumentError)
+        expect { p.with({ :foo => 3 , :bar => "baz" }) }.to raise_error do |error|
+          expect(error).to be_a(Values::ArgumentError)
+          expect(error.unexpected_keys).to contain_exactly(:foo, :bar)
+          expect(error.missing_keys).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
I hesitate to make this PR given that part of Values' appeal is its exceptionally small size; so, apologies in advance if the changeset it unwanted, and thanks for taking the time to review it.

I use Values for input validation and would find it helpful if the exceptions raised by the `.new` and `.with` methods upon receipt of bad arguments contained lists of missing and unrecognized keys, along the same lines as how [virtus](https://github.com/solnic/virtus)'s [`CoercionError`](https://github.com/solnic/virtus/blob/9b23ca58342e6a3ca4cfc5a495ee50a62f19a978/lib/virtus.rb#L13-L40) exception class has the `.attribute_name` method for helping to determine which failed attribute prevented an object's instantiation.

Since Values already validates constructor arguments, this PR mostly amounts to percolating existing data up to the caller -- the exception being the second argument to the `Values::ArgumentError` created in `.new`.

The convention I've followed is that the `@missing_keys` and `@unexpected_keys` attributes will contain empty arrays if there were, respectively, no missing arguments or no extra arguments to `.with`.  By contrast, `@unexpected_keys` will be `nil` if there were extra arguments provided to `.new`, since there is no way to determine the 'meaning' of additional positional parameters in the absence of handy hash keys acting a labels.