### PR TITLE
Fix test breakage due to newer Rake incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ rvm:
   - jruby-19mode
   - jruby-18mode
   # Rubinius
-  - rbx-3
+  - rubinius-3
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,36 @@
 language: ruby
+
 cache: bundler
+
 sudo: false
+
+# See https://docs.travis-ci.com/user/languages/ruby/#Rubinius
+dist: trusty
+
 rvm:
+  # MRI
   - ruby-head
+  - 2.4
+  - 2.3
   - 2.2
   - 2.1
-  - 2.0.0
+  - 2.0
   - 1.9.3
   - 1.9.2
   - 1.8.7
   - ree
+  # JRuby
   - jruby-head
+  - jruby-9.1
+  - jruby-9.0
   - jruby-19mode
   - jruby-18mode
-  - rbx-2
+  # Rubinius
+  - rbx-3
+
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-3
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ rvm:
   - 2.1
   - 2.0
   - 1.9.3
-  - 1.9.2
   - 1.8.7
   - ree
   # JRuby
@@ -31,6 +30,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 1.9.2 # See build error https://travis-ci.org/tcrayford/Values/jobs/202728857
     - rvm: jruby-head
     - rvm: rbx-3
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 
-cache: bundler
-
-sudo: false
+# Apparently sudo is required to test on Rubinius and JRuby-head
+sudo: required
 
 # See https://docs.travis-ci.com/user/languages/ruby/#Rubinius
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - 2.2
   - 2.1
   - 2.0
+  - 1.9.2 # allowed to fail until Travis binary for this is fixed
   - 1.9.3
   - 1.8.7
   - ree

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,5 @@ matrix:
     - rvm: ruby-head
     - rvm: 1.9.2 # See build error https://travis-ci.org/tcrayford/Values/jobs/202728857
     - rvm: jruby-head
-    - rvm: rbx-3
+    - rvm: rubinius-3
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,21 @@ source 'https://rubygems.org'
 
 group :test do
   if RUBY_VERSION >= '2.2'
-    gem 'rake'
+    # WORKAROUND (2017-02-17): Rake 11.0 breaks RSpec < 3.5. We stay with
+    #   older RSpec to test older Rubies, so we must pin Rake version.
+    # See: http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11
+    gem 'rake', '< 11.0'
+
+    # Only bother supporting code coverage on relatively recent Rubies
     gem 'codecov', :require => false
   else
+    # Avoid incompatibilities that break builds on Ruby 1.8.7, until we drop support
     gem 'rake', '~> 10.4'    
   end
 end
 
+# Only support building documentation, and therefore supporting those
+# dependencies, on recent MRI Rubies when not running on Travis CI.
 if (defined?(RUBY_ENGINE) && 
     RUBY_ENGINE == 'ruby' && 
     RUBY_VERSION >= '2.2' &&


### PR DESCRIPTION
Pin max Rake version to `< 11.0`. 

See the following for more info:
http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11