### PR TITLE
Add Value.from method

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ Point.with(x: 1, y: -1).to_h
 # => {:x=>1, :y=>-1}
 ```
 
+And can be created from an object:
+
+```ruby
+some_hash = { value: 42, other_value: true }
+
+o1 = Value.from(some_hash)
+o2 = Value.from(some_hash)
+
+o1 == o2 # => true
+
+o1.value # => 42
+o1.other_value # => true
+
+o1.other_key # => NoMethodError
+```
+
 Values also supports customization of value classes inheriting from `Value.new`:
 
 ```ruby

--- a/lib/values.rb
+++ b/lib/values.rb
@@ -92,6 +92,10 @@ class Value
         Hash[to_a]
       end
 
+      def to_hash
+        to_h
+      end
+
       def recursive_to_h
         Hash[to_a.map{|k, v| [k, Value.coerce_to_h(v)]}]
       end
@@ -102,6 +106,14 @@ class Value
 
       class_eval &block if block
     end
+  end
+
+  def self.from(hash_or_coercible_object)
+    coerced = Hash(hash_or_coercible_object)
+    keys = coerced.keys
+
+    klass_cache[keys] ||= new(*keys)
+    klass_cache[keys].with(coerced)
   end
 
   protected
@@ -117,5 +129,11 @@ class Value
     else
       v
     end
+  end
+
+  private
+
+  def self.klass_cache
+    @klass_cache ||= {}
   end
 end

--- a/values.gemspec
+++ b/values.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.licenses    = ["MIT"]
 
   gem.required_ruby_version = ">= 1.8.7"
-  gem.add_development_dependency "rspec", "~> 2.11.0"
+  gem.add_development_dependency "rspec", "~> 2.14.0"
 
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Adds the `Value.from` method to allow a `Hash` (or Hash-coercible object) to be converted into a Value object.

# Proposed API

```ruby
some_hash = { value: 42, other_value: true }

o1 = Value.from(some_hash)
o2 = Value.from(some_hash)

o1 == o2 # => true

o1.value # => 42
o1.other_value # => true

o1.other_key # => NoMethodError
```

This PR bumps the RSpec version to 2.14.x to add the `and_call_original` feature on mocks.