### PR TITLE
Optimize initializer

### DIFF
--- a/lib/values.rb
+++ b/lib/values.rb
@@ -23,6 +23,11 @@ class Value
     Class.new do
       attr_reader(:hash, *fields)
 
+      # Unroll the fields into a series of assignment Ruby statements that can
+      # be used inside of the initializer for the new class. This was introduced
+      # in PR#56 as a performance optimization -- it ensures that this iteration
+      # happens once per class, instead of happening once per instance of the
+      # class.
       instance_var_assignments = Array.new(fields.length) do |idx|
         "@#{fields[idx]} = values[#{idx}]"
       end.join("\n")


### PR DESCRIPTION
We use the Values gem extensively in our application and in some pipelines allocate hundreds of thousands of these objects. As a result we're particularly sensitive to the performance of the ``#initialize`` method.

By switching from ``define_method`` to a ``class_eval``, we roughly 2x the number of allocations that can be performed in a given timespan:
```
Warming up --------------------------------------
               value    16.766k i/100ms
              value2    31.020k i/100ms
Calculating -------------------------------------
               value    182.303k (± 3.3%) i/s -    922.130k in   5.063815s
              value2    337.187k (± 3.7%) i/s -      1.706M in   5.066975s
true
```
value is the original implementaion and value2 is the code provided in this patch. See https://gist.github.com/michaeldiscala/cee9dbefa06e0d73e15d5bb095ba11bd for the benchmark script.