### PR TITLE
Optimize `#eql?`

### DIFF
--- a/lib/values.rb
+++ b/lib/values.rb
@@ -68,8 +68,17 @@ class Value
         eql?(other)
       end
 
+      # Optimized to check for same instance and for different hash code, and
+      # avoids intermediate Array instantiation to check fields.
       def eql?(other)
-        self.class == other.class && values == other.values
+        self.equal?(other) ||
+          (
+            self.class == other.class &&
+              self.hash == other.hash &&
+              self.class::VALUE_ATTRS.all? do |field|
+                send(field) == other.send(field)
+              end
+          )
       end
 
       def values


### PR DESCRIPTION
**NOTE:** Currently this commit is based of of PR #57, but can be separated if necessary.

Speed improvements:

| When you have...     | Delta IPS |
| -------------------- | --------- |
| Same instance        |     **15.6x** |
| Different last field |     **10.2x** |
| Equal fields         |      **1.4x** |

Benchmarking gist:
https://gist.github.com/ms-ati/3e62cca57ca32cd17ad2e2e2b14cc65e

Explanation of changes:

It came as a surprise to see the humble `#eql?` comparison in profiling --
we had not realized that in Ruby, if one wants to short-circuit comparison
of a single instance of an object to itself, for example, that this logic
must be explicitly added to `#eql?`. This accounts for **15.6x** difference
in iterations-per-second of same-instance comparison.

Furthermore, the cost of pre-calculating `hash` is already being paid at
instantiation of every value object. So we add an early exit if the hash
does not match. This accounts for **10.2x** difference in iterations-per-second
of comparisons of instances that differ in only the last field.

Finally, the cost of instantiating two temporary Array instances is
significant when comparing two distinct instances which have equal field
values. So we iterate the field comparisons without the temporary
Arrays. This accounts for the **1.4x** difference in iterations-per-second
of comparisons of distinct instances with equal field values.